### PR TITLE
Fix example dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,160 +54,160 @@ harness = false
 
 [[example]]
 name = "perlin"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "perlin_surflet"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "open_simplex"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "super_simplex"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "value"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "constant"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "checkerboard"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "cylinders"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "select"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "blend"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "abs"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "clamp"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "curve"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "exponent"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "negate"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "scale_bias"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "terrace"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "add"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "max"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "min"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "multiply"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "power"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "fbm"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "billow"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "basicmulti"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "ridgedmulti"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "hybridmulti"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "cache"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "worley"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "displace"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "rotate_point"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "scale_point"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "translate_point"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "turbulence"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "texturewood"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "texturejade"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "texturegranite"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "textureslime"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "complexplanet"
-required-features = ["image"]
+required-features = ["images"]
 
 [[example]]
 name = "simplex"
-required-features = ["image"]
+required-features = ["images"]


### PR DESCRIPTION
Each example uses NoiseImage::write_to_file, which uses cfg(feature="images"). (note, "images", not "image"). 

Previously, running an example without features would give an error like: `target 'perlin' in package 'noise' requires the features: 'image'`, and running again with feature 'image' would give: `no method named 'write_to_file' found for struct 'NoiseMap' in the current scope`. Running again with feature 'images' works as expected.